### PR TITLE
Fix maxWidth check for 32-bit architectures

### DIFF
--- a/format.go
+++ b/format.go
@@ -80,7 +80,7 @@ func AppendFormat(buf []byte, t time.Time, format string) []byte {
 					b = format[i]
 					if b <= '9' && '0' <= b {
 						width = width*10 + int(b&0x0F)
-						if width >= 0xCCCCCCCCCCCCCCC {
+						if int64(width) >= 0xCCCCCCCCCCCCCCC {
 							width = maxWidth
 						}
 					} else {


### PR DESCRIPTION
`0xCCCCCCCCCCCCCCC` constant overflows int on 32-bit architectures.

```
GOOS=linux GOARCH=386 go build .
# github.com/itchyny/timefmt-go
./format.go:83:16: constant 922337203685477580 overflows int
```