### PR TITLE
Support parsing mixed %Z and %z

### DIFF
--- a/parse_test.go
+++ b/parse_test.go
@@ -445,7 +445,7 @@ var parseTestCases = []struct {
 	{
 		source: "2020-07-24 23:14:15 +0000",
 		format: "%F %T %z",
-		t:      time.Date(2020, time.July, 24, 23, 14, 15, 0, time.UTC),
+		t:      time.Date(2020, time.July, 24, 23, 14, 15, 0, time.FixedZone("", 0)),
 	},
 	{
 		source: "2020-07-24T23:14:15Z",
@@ -742,6 +742,14 @@ func TestParse(t *testing.T) {
 				}
 				if !got.Equal(tc.t) {
 					t.Errorf("expected: %v, got: %v", tc.t, got)
+				}
+				name, offset := tc.t.Zone()
+				gotName, gotOffset := got.Zone()
+				if name != gotName || offset != gotOffset {
+					t.Errorf("expected zone: name = %s, offset = %d, got zone: name = %s, offset = %d",
+						name, offset,
+						gotName, gotOffset,
+					)
 				}
 			} else {
 				if err == nil {

--- a/parse_test.go
+++ b/parse_test.go
@@ -703,6 +703,16 @@ var parseTestCases = []struct {
 		parseErr: errors.New(`cannot parse "X" with "%Z"`),
 	},
 	{
+		source: "2020-07-24 23:14:15 +0530 (AAA)",
+		format: "%F %T %z (%Z)",
+		t:      time.Date(2020, time.July, 24, 23, 14, 15, 0, time.FixedZone("AAA", (5*60+30)*60)),
+	},
+	{
+		source: "2020-07-24 23:14:15 (AAA) +0530",
+		format: "%F %T (%Z) %z",
+		t:      time.Date(2020, time.July, 24, 23, 14, 15, 0, time.FixedZone("AAA", (5*60+30)*60)),
+	},
+	{
 		source: "01%02\t03\n450000",
 		format: "%H%%%M%t%S%n%f",
 		t:      time.Date(1900, time.January, 1, 1, 2, 3, 450000000, time.UTC),


### PR DESCRIPTION
This PR add a feature parsing mixed `%Z` and `%z` (e.g. `Thu, 20 Oct 2022 02:14:22 -0600 (CST)`) into correct zone information.
That format can be found in the `Date` header of some emails, for example.