### PR TITLE
Use default UTC offset for %Z format with "Z" value

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -173,7 +173,11 @@ func parse(source, format string, loc, base *time.Location) (t time.Time, err er
 						break
 					}
 				}
-				t, err = time.ParseInLocation("MST", source[j:k], base)
+				zone := source[j:k]
+				if zone == "Z" {
+					zone = time.UTC.String()
+				}
+				t, err = time.ParseInLocation("MST", zone, base)
 				if err != nil {
 					err = fmt.Errorf(`cannot parse %q with "%%Z"`, source[j:k])
 					return

--- a/parse_test.go
+++ b/parse_test.go
@@ -453,6 +453,11 @@ var parseTestCases = []struct {
 		t:      time.Date(2020, time.July, 24, 23, 14, 15, 0, time.UTC),
 	},
 	{
+		source: "2020-07-24T23:14:15Z",
+		format: "%FT%T%Z",
+		t:      time.Date(2020, time.July, 24, 23, 14, 15, 0, time.UTC),
+	},
+	{
 		source: "2020-07-24 23:14:15 -0800",
 		format: "%F %T %z",
 		t:      time.Date(2020, time.July, 24, 23, 14, 15, 0, time.FixedZone("", -8*60*60)),


### PR DESCRIPTION
## Related issue
https://github.com/itchyny/timefmt-go/issues/6

## Changes
This change adds ability to handle "Z" value for `%Z` format

## Testing
Added a unit test case 